### PR TITLE
Fix typo in Participant execute error message

### DIFF
--- a/tests/helpers/Participant.ts
+++ b/tests/helpers/Participant.ts
@@ -130,7 +130,7 @@ export class Participant {
         try {
             return await this.driver.execute(script, ...args);
         } catch (error) {
-            console.error('An error occured while trying to execute a script: ', error);
+            console.error('An error occurred while trying to execute a script: ', error);
             throw error;
         }
     }


### PR DESCRIPTION
## Summary
- fix spelling of "occurred" in `Participant.execute` error message

## Testing
- `npm run lint -s` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686136697d18832ca273d2e6c74cce4c